### PR TITLE
Optic: modified api command, added optic task

### DIFF
--- a/optic.yml
+++ b/optic.yml
@@ -3,5 +3,8 @@ tasks:
   start:
     command: node bin/www
     baseUrl: http://localhost:38080
+  pm2-start:
+    baseUrl: http://localhost:3000
+    proxy: http://localhost:3300
 ignoreRequests:
 - OPTIONS *

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "start": "npm run pm2 && pm2 flush && pm2 log api",
-    "pm2": "pm2 start pm2-env.config.js --only api-rest"
+    "pm2": "pm2 start pm2-env.config.js --only api-rest && api run pm2-start"
   },
   "dependencies": {
     "bcrypt": "^4.0.1",


### PR DESCRIPTION
I'll follow up in [Issue 228 on Optic](https://github.com/opticdev/optic/issues/228) with details. The summary is, using `api`/Optic to run a command implies to Optic that it should watch the lifecycle of that command. This works great for applications that run directly (such as a `node bin/www`) but is a bad assumption when using tooling like pm2. The `pm2` invocation to spin up services is designed to be short-lived (it triggers other tasks and then quits, letting the background daemon do continuing work). Optic gets confused.

We're actively working this cycle on improving another mode of operation, that works more like a transparent proxy. Instead of watching the process lifecycle, we provide a proxy that runs independent of the command. It's an undocumented feature as it's still under active development, though the following example should help for its current state:

- optic.yml task `pm2-start`
  - in this mode, `baseUrl` is the URL of the process to monitor. In this example, `api-rest` is using port 3000 so that's where we point the baseUrl.
  - `proxy` in this mode is where we want to send traffic for observation. This is what we'd call baseUrl in the start command above, if we were using the command mode (there port 38080 was used to avoid contention with other applications)
  - Note: these configurations are likely to change as we finish the work on this feature and document it. It's a bit confusing right now, as baseUrl behaves differently depending on the mode.
- package.json script `pm2`
  - added `&& api run pm2-start` to the end. This runs the Optic proxy task assuming the pm2 startup task runs successfully.

## Invocation

`npm start pm2`

## Use

Navigate to your API through the `proxy` URL (here http://localhost:3300). This allows Optic to observe traffic and start building documentation. The only gotcha is that Optic will assume one long capture session, as it won't be aware of application restarts as it's not watching a process directly. Generally, the Optic proxy can be killed and restarted when there's significant code changes and you'd like to start a fresh capture (say, a route was not functioning as intended and you want to wipe out old captures and start over). The best way to do that will depend on your workflow, and I'm happy to chat more if that will help.